### PR TITLE
Performance tuning

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -44,7 +44,7 @@ class DBWNode(object):
         wheel_base = rospy.get_param('~wheel_base', 2.8498)
         steer_ratio = rospy.get_param('~steer_ratio', 14.8)
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
-        max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
+        max_steer_angle = rospy.get_param('~max_steer_angle', 4.)
 
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
                                          SteeringCmd, queue_size=1)

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -252,7 +252,8 @@ bool PurePursuit::verifyFollowing() const
 geometry_msgs::Twist PurePursuit::calcTwist(double curvature, double cmd_velocity) const
 {
   // verify whether vehicle is following the path
-  bool following_flag = verifyFollowing();
+  // bool following_flag = verifyFollowing();
+  bool following_flag = false;
   static double prev_angular_velocity = 0;
 
   geometry_msgs::Twist twist;

--- a/ros/src/waypoint_loader/launch/waypoint_loader.launch
+++ b/ros/src/waypoint_loader/launch/waypoint_loader.launch
@@ -2,6 +2,6 @@
 <launch>
     <node pkg="waypoint_loader" type="waypoint_loader.py" name="waypoint_loader">
         <param name="path" value="$(find styx)../../../data/wp_yaw_const.csv" />
-        <param name="velocity" value="10" />
+        <param name="velocity" value="40" />
     </node>
 </launch>


### PR DESCRIPTION
Here are the code changes:

    ros/src/twist_controller/dbw_node.py
    Reduced the max_steer_angle to 4. (from original value 8.)

    ros/src/twist_controller/twist_controller.py
    Added a PID controller for steering.
    The max_steer_angle is used in this PID controller.
    Also applied LowPass filtering to steering.

    ros/src/waypoint_follower/src/pure_pursuit_core.cpp
    In PurePursuit::calcTwist(), set following_flag to false.

    ros/src/waypoint_loader/launch/waypoint_loader.launch
    Bumped the speed back to 40.